### PR TITLE
fixed error in calculation of B_f by adding parenthesis

### DIFF
--- a/pydsm/iso226.py
+++ b/pydsm/iso226.py
@@ -269,8 +269,8 @@ def tabled_B_f(L_p, hfe=False):
     reference pressure level P0 (close to the hearing threshold at 1 kHz and
     set to 20 uPa RMS).
     """
-    B_f = ((0.4*10**(L_p+tbl_L_U)/10.-9.)**tbl_alpha_f -
-           (0.4*10**(tbl_T_f+tbl_L_U)/10.-9.)**tbl_alpha_f +
+    B_f = ((0.4*10**((L_p+tbl_L_U)/10.-9.))**tbl_alpha_f -
+           (0.4*10**((tbl_T_f+tbl_L_U)/10.-9.))**tbl_alpha_f +
            0.005135)
     return np.append(B_f, B_f[0]) if hfe else B_f
 


### PR DESCRIPTION
According to "Parmanen, Juhani. (2012). Some Reasons to Revise the International Standard ISO 226:2003: Acoustics—Normal Equal-Loudness-Level Contours. Open Journal of Acoustics. 2. 143-149. 10.4236/oja.2012.24016.)", dividing by 10 and subtracting 9 is in the exponent.

Regards
